### PR TITLE
add a default network to docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,3 +43,11 @@ services:
     volumes:
       - ./src:/var/www/html
 
+networks:
+  dockerbridge.local:
+    name: laravel_dockerized_network
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.100.0/24


### PR DESCRIPTION
With this PR we are adding the first network to the docker compose then we can use it for phpmyadmin connecting to mysql.