### PR TITLE
add phpmyadmin to services docker compose and updating README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ To upgrade the project you need to pull and re-create containers with the latest
 So you can stop containers and then run docker-composer with this options:
 
 docker-compose up --force-recreate --build -d server
+
+### Services Guide
+#### PhpMyadmin
+To run this service simply use this command:
+  ```sh
+  docker-compose up -d phpmyadmin
+  ```
+Then you can open 192.168.10.80 to see phpmyadmin login page.
+Mysql user definition is in env/mysql.env you can use them to log in.
+To change the ip or port you can simply edit docker-compose.yml and phpmyadmin service. 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,6 +23,9 @@ services:
     image: mysql:5.7
     env_file:
       - ./env/mysql.env
+    networks:
+      dockerbridge.local:
+        ipv4_address: 192.168.10.50
   composer:
     build:
       context: dockerfiles
@@ -42,6 +45,16 @@ services:
     entrypoint: [ "npm" ]
     volumes:
       - ./src:/var/www/html
+  phpmyadmin:
+    image: phpmyadmin
+    restart: always
+    ports:
+      - 8080:80
+    environment:
+      - PMA_ARBITRARY=1
+    networks:
+      dockerbridge.local:
+        ipv4_address: 192.168.10.80
 
 networks:
   dockerbridge.local:
@@ -50,4 +63,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 192.168.100.0/24
+        - subnet: 192.168.10.0/24


### PR DESCRIPTION
With this PR I added phpmyadmin services to docker-compose.yml and we can use it by opening the IP. the full changes are documented in README.md.